### PR TITLE
Add Workdir /data to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk --no-cache --no-progress add ca-certificates tzdata\
     && rm -rf /var/cache/apk/*
 
 COPY --from=builder /go/traefik-migration-tool/traefik-migration-tool .
+WORKDIR /data
 
 ENTRYPOINT ["/traefik-migration-tool"]
 CMD ["-h"]


### PR DESCRIPTION
In the example documentation and image, it asks that you mount the volume `${PWD}:/data` in order to copy local content into the Docker image. However, the default commands don't work `static`, `acme`, and `ingress` as they run the command from the `/` of the container and not the working Dir `/data``

I've now defaulted the Working Dir to `/data`