### PR TITLE
Fixed Global to return Nil if nothing present

### DIFF
--- a/static/configuration.go
+++ b/static/configuration.go
@@ -24,10 +24,12 @@ func migrateConfiguration(oldCfg Configuration) static.Configuration {
 		fmt.Println("Web must be converted manually. See https://docs.traefik.io/operations/api/")
 	}
 
+	if oldCfg.Global == nil {
+		return nil
+	}
+
 	return static.Configuration{
-		if oldCfg.Global == nil {
-			return nil
-		}
+		
 			
 		Global: &static.Global{
 			CheckNewVersion:    oldCfg.CheckNewVersion,

--- a/static/configuration.go
+++ b/static/configuration.go
@@ -25,6 +25,10 @@ func migrateConfiguration(oldCfg Configuration) static.Configuration {
 	}
 
 	return static.Configuration{
+		if oldCfg.Global == nil {
+			return nil
+		}
+			
 		Global: &static.Global{
 			CheckNewVersion:    oldCfg.CheckNewVersion,
 			SendAnonymousUsage: oldCfg.SendAnonymousUsage,


### PR DESCRIPTION
Fixed the Global configuration. If no value was present it was still adding it to the new-traefik.toml/.yml. Now, if no value is present it will return Nil following the other configurations.